### PR TITLE
refactor: extract AGENTS.md domain knowledge into 3 project skills

### DIFF
--- a/.agents/skills/intellij-disposable/SKILL.md
+++ b/.agents/skills/intellij-disposable/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: intellij-disposable
+description: IntelliJ plugin Disposable/CoroutineScope lifecycle patterns. Use when registering services, listeners, or UserData that must clean up on plugin unload.
+---
+
+# IntelliJ Disposable 与 CoroutineScope 生命周期
+
+动态插件必须在卸载时正确清理所有注册。每个注册点都应传递 `Disposable` 或 `CoroutineScope`。
+
+## CoroutineScope 注入 Service
+
+在 Service 中通过主构造函数声明 `CoroutineScope`，由平台管理生命周期：
+
+```kotlin
+@Service
+class MyService(private val scope: CoroutineScope) {
+    // scope 在插件卸载时自动 cancel
+}
+```
+
+## 动态插件注册
+
+所有注册 API（listener、executor、scheduler 等）都必须传入 `Disposable` 或 `CoroutineScope`：
+
+```kotlin
+// 传入 Disposable — 插件卸载时自动取消注册
+connection.subscribe(MY_TOPIC, disposable, myHandler)
+
+// 传入 CoroutineScope — scope cancel 时清理
+scope.launch {
+    // 异步工作
+}
+```
+
+## UserDataHolder 清理
+
+`UserDataHolder.putUserData()` 存储的数据必须配合 `Disposable` 清理，防止内存泄漏。
+
+推荐使用 `AutoCleanKey`（详见 [intellij-shared-AutoCleanKey](../intellij-shared-AutoCleanKey/SKILL.md)）：
+
+```kotlin
+val key = Key.create<String>("my.key")
+val cleaner = AutoCleanKey(disposable, key)
+
+// Kotlin 委托属性，disposable 释放时自动 removeUserData
+var myValue: String? by cleaner
+```
+
+## PluginDisposable 样板
+
+每个插件应提供一个全局级 Disposable，用于插件级注册：
+
+```kotlin
+@Service
+private class PluginDisposable : Disposable.Default
+
+@Suppress("LocalVariableName")
+internal val PluginDisposable
+    get() = service<PluginDisposable>()
+```
+
+使用示例：
+
+```kotlin
+connection.subscribe(MY_TOPIC, PluginDisposable, myHandler)
+```

--- a/.agents/skills/intellij-psi-vfs-safety/SKILL.md
+++ b/.agents/skills/intellij-psi-vfs-safety/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: intellij-psi-vfs-safety
+description: PSI/VFS/Document thread-safety rules for IntelliJ plugin development. Use when reading/writing PSI trees, Documents, or VFS files.
+---
+
+# PSI / VFS / Document 线程安全
+
+## 1. PSI 读取必须在 readAction 内
+
+所有 PSI 读取必须运行在 `readAction`/`runReadAction` 内，除非特定 PSI API 显式文档说明不同的安全访问合约。
+
+```kotlin
+// 正确
+val text = readAction { psiFile.text }
+
+// 错误 — 可能不在读锁中
+val text = psiFile.text
+```
+
+## 2. Document 读取需要 committed document + read access
+
+需要与 PSI、committed offset、navigation/symbol resolution 保持一致的 Document 读取，必须使用 committed document 并在 read access 下进行。
+
+```kotlin
+val doc = PsiDocumentManager.getInstance(project).getLastCommittedDocument(psiFile)
+val offset = readAction { doc?.getLineStartOffset(line) }
+```
+
+## 3. VFS 读写遵循 API 锁合同
+
+VFS 读写遵循具体 API 的锁注解（`@RequiresReadLock`、`@RequiresWriteLock`）和文档合同。当需要与 PSI/Document 状态保持一致性快照时，获取对应的 read/write access。
+
+## 4. 内部辅助函数不假设调用者上下文
+
+对于读取 PSI/Document 或需要 VFS access 约束的内部辅助函数，不假设调用者已持有正确的锁。在深层辅助函数中添加显式守卫：
+
+```kotlin
+fun readPsi(psiFile: PsiFile): String {
+    ApplicationManager.getApplication().assertReadAccessAllowed()
+    return psiFile.text
+}
+```
+
+## 5. 修改 Document 后必须 commit
+
+在 write action 中修改编辑器 `Document` 后，必须在返回前调用：
+
+```kotlin
+writeAction {
+    document.insertString(offset, text)
+    PsiDocumentManager.getInstance(project)
+        .doPostponedOperationsAndUnblockDocument(document)
+    PsiDocumentManager.getInstance(project).commitDocument(document)
+}
+```
+
+## 6. 基于 offset 的导航/符号工具使用 committed document
+
+```kotlin
+val committedDoc = PsiDocumentManager.getInstance(project)
+    .getLastCommittedDocument(psiFile)
+// 使用 committedDoc 进行 offset 计算和符号解析
+```
+
+## 7. committed document 不可用时显式报错
+
+如果 `getLastCommittedDocument` 返回 null，返回清晰的 retriable 错误消息，让调用方 commit/retry，而不是静默使用可能过期的未提交状态。

--- a/.agents/skills/intellij-shared-AutoCleanKey/SKILL.md
+++ b/.agents/skills/intellij-shared-AutoCleanKey/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: intellij-shared-AutoCleanKey
+description: AutoCleanKey usage guide for UserData lifecycle management in IntelliJ plugins. Use when working with UserDataHolder cleanup tied to Disposable or CoroutineScope.
+---
+
+# intellij-shared 公用模块
+
+`modules/intellij-shared` 提供跨插件共享的工具类。当前包含 `AutoCleanKey`。
+
+## 模块依赖
+
+在插件的 `build.gradle.kts` 中添加：
+
+```kotlin
+dependencies {
+    implementation(project(":modules:intellij-shared"))
+}
+```
+
+## AutoCleanKey
+
+`AutoCleanKey` 封装 `Key<T>`，在关联的 `Disposable` 或 `CoroutineScope` 结束时自动清理所有使用该 key 的 `UserDataHolder`。避免手动管理 `removeUserData`。
+
+### 构造方式
+
+```kotlin
+val key = Key.create<String>("my.key")
+
+// 1. 直接绑定 Disposable
+val cleaner = AutoCleanKey(disposable, key)
+
+// 2. 延迟解析 Disposable（仅在首次 track 时调用 provider）
+val cleaner = AutoCleanKey({ getDisposable() }, key)
+
+// 3. 绑定 CoroutineScope（内部创建 Disposable，scope 结束时自动 dispose）
+val cleaner = AutoCleanKey(scope, key)
+```
+
+### toAutoCleanKey 扩展
+
+从已有 `Key` 创建 `AutoCleanKey`：
+
+```kotlin
+val cleaner = myKey.toAutoCleanKey { disposable }
+val cleaner = myKey.toAutoCleanKey(scope)
+```
+
+### Kotlin 委托属性
+
+```kotlin
+val holder = object : UserDataHolderBase() {
+    var value: String? by cleaner  // getValue/setValue 自动 track holder
+}
+```
+
+支持的 Key 类型：
+- `Key<T>` — 可空值
+- `KeyWithDefaultValue<T>` — 带默认值，未设置时返回 `defaultValue`
+- `NotNullLazyKey<T, H>` — 惰性计算，首次访问调用 factory
+
+### 清理行为
+
+当 `Disposable` 被 dispose 或 `CoroutineScope` 完成时，所有通过委托属性访问过该 key 的 `UserDataHolder` 上的该 key 都会被自动 `removeUserData`。一个 `AutoCleanKey` 可被多个 holder 复用。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,127 +2,75 @@
 
 ## Coding
 
-1. use kotlin for plugin development
-2. use kotlin coroutines whenever possible for asynchronous operations, including Psi/Vfs
-   read/write actions, progress reporting,
-   background tasks, and some cancelable registrations. Avoid blocking the UI thread.
-3. you should declare `CoroutineScope` in Service as primary constructor property when needed,
-   ensuring proper lifecycle, e.g. cancellation on plugin unload.
-4. make dynamic plugins, registering should pass a `Disposable`
-   or `CoroutineScope` to ensure proper cleanup on unload.
-5. clean data in `UserDataHolder` with `Disposable` or `CoroutineScope` to prevent memory leaks.
-6. DO NOT run blocking operations on UI Thread.
-7. `Dispatchers.EDT` means UI thread and `writeAction`, use `Dispatchers.UI` if no write access needed
-8. use explicit visibility modifiers, mostly should use `internal`
-9. DO NOT use `@ApiStatus.Internal` APIs, which will be prevented on marketplace, check before writing
-10. Use `@ApiStatus.Experimental` APIs with caution, as they may change without deprecation.
-    If you must use them, `Suppress` the `UnstableApiUsage` warning and document the usage clearly in code comments,
-    so future maintainers understand the risks and can track API changes in IntelliJ releases.
+- 使用 **Kotlin** 开发插件。
+- 异步操作（PSI/VFS 读写、进度报告、后台任务、可取消注册等）使用 **Kotlin 协程**，避免阻塞 UI 线程。
+- 不要在 UI 线程上运行阻塞操作。
+- `Dispatchers.EDT` = UI 线程 + writeAction。不需要写权限时使用 `Dispatchers.UI`。
+
+```kotlin
+import com.intellij.openapi.application.backgroundWirteAction
+import com.intellij.openapi.application.readAction
+// 读 PSI — 不需要 writeAction
+val text = readAction { psiFile.text }
+
+// 写 Document — 需要 writeAction
+backgroundWirteAction { document.setText("new") }
+```
+
+- 使用显式可见性修饰符，默认使用 `internal`。
+- **禁止**使用 `@ApiStatus.Internal` API（Marketplace 会上会被拦截），使用前务必检查。
+- 谨慎使用 `@ApiStatus.Experimental` API（可能无废弃期变更）。若必须使用，`@Suppress("UnstableApiUsage")` 并在注释中说明原因，方便后续跟踪 IntelliJ 版本变更。
+
+Disposable 生命周期与清理模式参见 [intellij-disposable](.agents/skills/intellij-disposable/SKILL.md)。
 
 ## Project Structure
 
-1. this repository is a Gradle monorepo; `settings.gradle.kts` auto-includes each
-   directory under `plugins/` as `:plugins:<pluginName>`.
-2. current plugin directories:
-   `EnhancedHotSwapEnabler`, `GradleMcpTools`, `IdeaVimToggleIME`,
-   `LiveTemplatesWithSelection`, `macOSRecents`, `SpotlessIntegration`,
-   `VitePress`, `WorkspaceMcpTools`.
-3. most plugin modules should keep this layout:
-   `build.gradle.kts`, `src/`, `README.md`, `CHANGELOG.md`, `TODO.md`, and `api/*.api`
-   when the plugin exposes a stable external API.
-4. some plugins can have nested Gradle subprojects via `projects.txt`
-   (current example: `plugins/SpotlessIntegration/projects.txt` includes `ModelBuilderService`).
-   when adding/removing entries, keep directory names and Gradle includes in sync.
-5. `VitePress` currently does not fully follow the common documentation/layout convention.
-   if you touch it, align it with the common plugin layout where practical.
-6. treat generated/local artifacts as non-source: `**/build/`, `**/.gradle/`, `.idea/`,
-   `.intellijPlatform/`, and `**/.DS_Store`.
-7. every plugin should keep a root `TODO.md` for current planned/refactor work.
-   keep it short, actionable, and written in English.
-8. once a `TODO.md` plan is implemented, move its finalized notes into plugin-local `docs/`
-   using a descriptive filename (for example `<PluginName>-<Topic>.md`), then refresh `TODO.md`
-   with the next active plan items.
-
-## Tooling and MCP
-
-1. MUST use domain specific MCP tools if available instead of using terminal/shell tools
-2. for API lookup, prioritize MCP flow: search to get VFS URL, use VFS tools for content,
-   and use navigation/symbol tools for documentation whenever possible.
-
-## PSI/VFS Read-Write Safety
-
-1. all PSI reads must run inside `readAction`/`runReadAction`, unless a specific PSI API explicitly documents a
-   different safe access contract.
-2. `Document` reads that must stay consistent with PSI, committed offsets, or navigation/symbol resolution must use a
-   committed document and run under read access.
-   for pure document-only reads, follow the specific document API's contract when weaker locking is acceptable.
-3. for VFS reads/writes, follow the specific API's locking annotations and documented contract.
-   acquire read/write access when required by that contract, or when a consistent snapshot with PSI/document state is
-   needed.
-4. do not assume caller context for internal helpers that read PSI/document or require VFS access constraints.
-   add explicit guards where useful (for example read-access assertions in deep helper functions, committed-document
-   checks, or checks that match the VFS API contract being used).
-5. after mutating editor `Document` in write action, call
-   `PsiDocumentManager.doPostponedOperationsAndUnblockDocument(document)` and
-   `PsiDocumentManager.commitDocument(document)` before returning.
-6. for offset-based navigation/symbol tools, prefer committed documents from
-   `PsiDocumentManager.getLastCommittedDocument(psiFile)` to keep PSI/document consistent.
-7. if committed document is unavailable, fail with a clear retriable message
-   (ask caller to commit/retry) instead of silently using potentially stale/uncommitted state.
-
-## MCP Tool Contract
-
-1. prefer MCP-first design for library/code insight lookup.
-   do not parse IDE jars via shell tools unless MCP lookup path is exhausted and failure reasons are recorded.
-2. provide first-call shortcuts for agent usage with stable, non-interactive defaults.
-3. batch tools should provide `continueOnError` and per-item error payloads.
-4. use `reportActivity` for start/progress/finish on long-running tools.
-5. validate parameters early and use precise `mcpFail` messages with actionable guidance.
-6. extract repeated descriptions/logic to shared `common` helpers and constants.
-
-## Serialization Compatibility
-
-1. treat tool DTOs/enums as external contracts once released.
-2. when renaming enum values, keep backward-compatible aliases using `@JsonNames`, except when for MCP tools, where
-   AGENTS can understand the changes without notice.
-3. prefer additive changes over breaking removals; if removal is required, document migration.
-4. keep quick presets and scope/token contracts backward-compatible across versions.
-
-## Build and Gradle
-
-1. NEVER run `verifyPlugin`, which is time-consuming and can be done on CI
-2. a single Gradle sync takes about 1.5-2 minutes
-3. a single `buildPlugin` Gradle task may take about 2 minutes
-4. update the kotlin ABI file when changing public APIs
-5. use delicated MCP tools instead of commandline whenever possible
-
-## Diagnostics and Docs
-
-1. keep activity keys/messages in sync with tool lifecycle and remove stale keys when tool interfaces are removed.
-2. when adding/changing toolsets, update `README.md` and related design docs in `docs/`.
-3. maintain clear separation between implemented and planned items in docs to reduce agent confusion.
-4. record newly discovered first-call shortcuts and failure/retry patterns in docs incrementally.
-5. treat plugin `TODO.md` as a staging document only; completed work must be archived in `docs/`
-   with a topic-specific filename to keep planning and historical records separated.
-6. changelog entries should describe the final user-visible or integrator-visible outcome of a change.
-   do not list internal refactor steps, test-only work, or implementation mechanics unless they change external
-   behavior.
-7. manually add changelog entries only under the `Unreleased` section.
-   do not manually convert `Unreleased` entries into a dated version section unless the release automation itself is
-   being changed.
-8. version bumps are still required when preparing a release-oriented change.
-   CI owns the changelog rollover, but it does not replace updating the plugin version in Gradle metadata.
-
-## Common Pattern
-
-### plugin level disposable
-
-```kotlin
-@Service
-private class MyDisposable : Disposable.Default
-
-@Suppress("LocalVariableName")
-internal val PluginDisposable
-get() = service<PluginDisposable>()
+本仓库为 Gradle monorepo：`settings.gradle.kts` 自动将 `plugins/` 下每个目录注册为 `:plugins:<pluginName>`，`modules/` 下注册为 `:modules:<moduleName>`。
 
 ```
+IntelliJ-Plugins/
+├── plugins/
+│   ├── EnhancedHotSwapEnabler/
+│   ├── GradleMcpTools/
+│   ├── IdeaVimToggleIME/
+│   ├── LiveTemplatesWithSelection/
+│   ├── macOSRecents/
+│   ├── SpotlessIntegration/
+│   ├── VitePress/
+│   └── WorkspaceMcpTools/
+├── modules/
+│   └── intellij-shared/
+├── settings.gradle.kts
+└── build.gradle.kts
+```
+
+- 插件标准布局：`build.gradle.kts`、`src/`、`README.md`、`CHANGELOG.md`、`TODO.md`。
+- 部分插件通过 `projects.txt` 声明嵌套 Gradle 子项目（例：`plugins/SpotlessIntegration/projects.txt` 含 `ModelBuilderService`）。增删条目时保持目录名与 Gradle include 一致。
+- 每个插件根目录维护 `TODO.md`，记录当前计划/重构项，简短、可执行、英文。
+- 计划项完成后，将最终说明移入插件内的 `docs/<PluginName>-<Topic>.md`，然后刷新 `TODO.md` 为下一阶段计划。
+
+## PSI / VFS / Document
+
+PSI、VFS、Document 读写必须遵循 IntelliJ 线程模型与锁合同。
+
+参见 [intellij-psi-vfs-safety](.agents/skills/intellij-psi-vfs-safety/SKILL.md)。
+
+## Build & Gradle
+
+- **禁止**运行 `verifyPlugin`（耗时长，留给 CI）。
+- 单次 Gradle sync 约 1.5–2 分钟。
+- 单次 `buildPlugin` 约 2 分钟。
+- 修改 public API 时更新 Kotlin ABI 文件。
+- 使用专用 MCP 工具代替命令行操作。
+
+## Diagnostics & Docs
+
+- 文档中明确区分已实现项与计划项，减少 agent 困惑。
+- 插件 `TODO.md` 仅作为过渡文档；完成的工作必须归档到 `docs/`，使用主题明确的文件名，保持计划与历史记录分离。
+- Changelog 条目描述对最终用户或集成者可见的变更结果，不列出内部重构步骤、纯测试工作或实现细节。
+- 仅手动在 `Unreleased` 部分添加 changelog 条目。不要手动将 `Unreleased` 转为带日期的版本号段落（CI 负责 changelog rollover）。
+- 版本号提升仍需在发布变更时手动更新 Gradle metadata。
+
+## Shared Modules
+
+`AutoCleanKey` 使用指南参见 [intellij-shared-AutoCleanKey](.agents/skills/intellij-shared-AutoCleanKey/SKILL.md)。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,13 @@
 - `Dispatchers.EDT` = UI 线程 + writeAction。不需要写权限时使用 `Dispatchers.UI`。
 
 ```kotlin
-import com.intellij.openapi.application.backgroundWirteAction
+import com.intellij.openapi.application.backgroundWriteAction
 import com.intellij.openapi.application.readAction
 // 读 PSI — 不需要 writeAction
 val text = readAction { psiFile.text }
 
 // 写 Document — 需要 writeAction
-backgroundWirteAction { document.setText("new") }
+backgroundWriteAction { document.setText("new") }
 ```
 
 - 使用显式可见性修饰符，默认使用 `internal`。


### PR DESCRIPTION
## Summary

AGENTS.md from 128 lines of mixed-domain entries down to 83 lines — core conventions stay inline with code examples, domain-specific knowledge extracted into 3 project skills.

## What changed

- **Inline (AGENTS.md)**: Coding basics, Project Structure, Build & Gradle, Diagnostics & Docs — reorganized with code examples and a directory tree diagram.
- **Removed**: MCP tooling/contract/serialization sections (superseded by ongoing MCP refactor); agent behavior rules (not project-scoped).

## New skills (`.agents/skills/`)

| Skill | Coverage |
|-------|----------|
| `intellij-disposable` | Disposable/CoroutineScope lifecycle, UserDataHolder cleanup, PluginDisposable pattern |
| `intellij-psi-vfs-safety` | readAction, commitDocument, committed document, caller context guards |
| `intellij-shared-AutoCleanKey` | AutoCleanKey usage: 3 construction modes, `toAutoCleanKey` extensions, delegate properties |