### PR TITLE
Use VfsUtil.createDirectories in test setup methods

### DIFF
--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileAccessPolicyRoutesTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileAccessPolicyRoutesTest.kt
@@ -1,9 +1,16 @@
+/*
+ * Copyright (c) 2026 ghostflyby
+ * SPDX-FileCopyrightText: 2026 ghostflyby
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 package dev.ghostflyby.mcp.rest
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.util.io.toCanonicalPath
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.fixture.*
@@ -45,7 +52,7 @@ internal class FileAccessPolicyRoutesTest {
         Files.write(root.resolve("binary.bin"), byteArrayOf(0, 1, 2, 3))
         Files.writeString(root.resolve("ignored.generated"), "ignored")
         Files.writeString(root.resolve("visible.kt"), "class Visible")
-        Files.createDirectories(root.resolve("excluded"))
+        val excluded = VfsUtil.createDirectories(root.resolve("excluded").toCanonicalPath())
         Files.writeString(root.resolve("excluded/hidden.kt"), "class Hidden")
         Files.createDirectories(root.resolve("src"))
         Files.writeString(root.resolve("src/source.txt"), "source")
@@ -53,9 +60,6 @@ internal class FileAccessPolicyRoutesTest {
         Files.writeString(root.resolve("a_one.kt"), "class AOne")
         Files.writeString(root.resolve("b_two.kt"), "class BTwo")
         Files.writeString(root.resolve("c_three.kt"), "class CThree")
-
-        val excluded = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(root.resolve("excluded"))
-            ?: error("excluded dir missing")
         ApplicationManager.getApplication().runWriteAction {
             val model = ModuleRootManager.getInstance(moduleFixture.get()).modifiableModel
             var committed = false
@@ -156,8 +160,7 @@ internal class FileAccessPolicyRoutesTest {
 
         restTestApplication {
             val root = Path.of(requireNotNull(project.basePath))
-            val sourceRoot = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(root.resolve("src"))
-                ?: error("src dir missing")
+            val sourceRoot = VfsUtil.createDirectories(root.resolve("src").toCanonicalPath())
 
             ApplicationManager.getApplication().runWriteAction {
                 val model = ModuleRootManager.getInstance(moduleFixture.get()).modifiableModel

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileAccessPolicyRoutesTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileAccessPolicyRoutesTest.kt
@@ -9,8 +9,7 @@ package dev.ghostflyby.mcp.rest
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.util.io.toCanonicalPath
-import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.fixture.*
@@ -52,7 +51,7 @@ internal class FileAccessPolicyRoutesTest {
         Files.write(root.resolve("binary.bin"), byteArrayOf(0, 1, 2, 3))
         Files.writeString(root.resolve("ignored.generated"), "ignored")
         Files.writeString(root.resolve("visible.kt"), "class Visible")
-        val excluded = VfsUtil.createDirectories(root.resolve("excluded").toCanonicalPath())
+        Files.createDirectories(root.resolve("excluded"))
         Files.writeString(root.resolve("excluded/hidden.kt"), "class Hidden")
         Files.createDirectories(root.resolve("src"))
         Files.writeString(root.resolve("src/source.txt"), "source")
@@ -60,6 +59,9 @@ internal class FileAccessPolicyRoutesTest {
         Files.writeString(root.resolve("a_one.kt"), "class AOne")
         Files.writeString(root.resolve("b_two.kt"), "class BTwo")
         Files.writeString(root.resolve("c_three.kt"), "class CThree")
+
+        val excluded = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(root.resolve("excluded"))
+            ?: error("excluded dir missing")
         ApplicationManager.getApplication().runWriteAction {
             val model = ModuleRootManager.getInstance(moduleFixture.get()).modifiableModel
             var committed = false
@@ -160,7 +162,8 @@ internal class FileAccessPolicyRoutesTest {
 
         restTestApplication {
             val root = Path.of(requireNotNull(project.basePath))
-            val sourceRoot = VfsUtil.createDirectories(root.resolve("src").toCanonicalPath())
+            val sourceRoot = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(root.resolve("src"))
+                ?: error("src dir missing")
 
             ApplicationManager.getApplication().runWriteAction {
                 val model = ModuleRootManager.getInstance(moduleFixture.get()).modifiableModel

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/RestSessionRoutesTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/RestSessionRoutesTest.kt
@@ -9,7 +9,9 @@ package dev.ghostflyby.mcp.rest
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.util.io.toCanonicalPath
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.junit5.TestApplication
 import com.intellij.testFramework.junit5.fixture.*
@@ -52,7 +54,7 @@ internal class RestSessionRoutesTest {
     @BeforeEach
     fun refresh() {
         val nestedRootPath = projectPathFixture.get().resolve("nested-session-root")
-        nestedRootPath.createDirectories()
+        val nestedRoot = VfsUtil.createDirectories(nestedRootPath.toCanonicalPath())
         nestedRootPath.resolve("NestedRootFile.kt").writeText("class NestedRootFile")
         val globDir = projectPathFixture.get().resolve("glob")
         globDir.resolve("nested").createDirectories()
@@ -65,8 +67,6 @@ internal class RestSessionRoutesTest {
         externalPathFixture.get().resolve("nested").createDirectories()
         externalPathFixture.get().resolve("nested/ExternalSearch.kt")
             .writeText("""class ExternalSearch { val marker = "external needle" }""")
-        val nestedRoot = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(nestedRootPath)
-            ?: error("nested root missing")
         ApplicationManager.getApplication().runWriteAction {
             val model = ModuleRootManager.getInstance(moduleFixture.get()).modifiableModel
             var committed = false


### PR DESCRIPTION
Refactor test setup methods by replacing custom directory creation logic with `VfsUtil.createDirectories`. This simplifies the code and ensures consistent behavior across tests. No functional changes.