### PR TITLE
Make Kotlin K2 dependency optional via k2-workaround file

### DIFF
--- a/plugins/GradleTypesafeConventions/src/main/resources/META-INF/k2-workaround.xml
+++ b/plugins/GradleTypesafeConventions/src/main/resources/META-INF/k2-workaround.xml
@@ -1,6 +1,0 @@
-<!-- Copyright (c) 2026 ghostflyby -->
-<!-- SPDX-FileCopyrightText: 2026 ghostflyby -->
-<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
-
-<idea-plugin>
-</idea-plugin>

--- a/plugins/GradleTypesafeConventions/src/main/resources/META-INF/k2-workaround.xml
+++ b/plugins/GradleTypesafeConventions/src/main/resources/META-INF/k2-workaround.xml
@@ -1,0 +1,6 @@
+<!-- Copyright (c) 2026 ghostflyby -->
+<!-- SPDX-FileCopyrightText: 2026 ghostflyby -->
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+
+<idea-plugin>
+</idea-plugin>

--- a/plugins/GradleTypesafeConventions/src/main/resources/META-INF/plugin.xml
+++ b/plugins/GradleTypesafeConventions/src/main/resources/META-INF/plugin.xml
@@ -11,12 +11,11 @@
     <depends>com.intellij.java</depends>
     <depends>com.intellij.gradle</depends>
     <depends>org.jetbrains.kotlin</depends>
-    <depends optional="true" config-file="k2-workaround.xml">com.intellij.modules.kotlin.k2</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.toml.lang</depends>
     <depends optional="true" config-file="gradle-typesafe-conventions-groovy.xml">org.intellij.groovy</depends>
     <extensions defaultExtensionNs="org.jetbrains.kotlin">
-        <supportsKotlinPluginMode supportsK2="true"/>
+        <supportsKotlinPluginMode supportsK2="true" supportsK1="false"/>
         <psiReferenceProvider
                 implementation="dev.ghostflyby.typesafeconventions.gradle.TypesafeConventionsKotlinCatalogPsiReferenceProviderContributor"/>
     </extensions>

--- a/plugins/GradleTypesafeConventions/src/main/resources/META-INF/plugin.xml
+++ b/plugins/GradleTypesafeConventions/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
     <depends>com.intellij.java</depends>
     <depends>com.intellij.gradle</depends>
     <depends>org.jetbrains.kotlin</depends>
-    <depends>com.intellij.modules.kotlin.k2</depends>
+    <depends optional="true" config-file="k2-workaround.xml">com.intellij.modules.kotlin.k2</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
     <depends>org.toml.lang</depends>
     <depends optional="true" config-file="gradle-typesafe-conventions-groovy.xml">org.intellij.groovy</depends>


### PR DESCRIPTION
Added a `k2-workaround` configuration file that makes the Kotlin K2 dependency optional. This prevents verifier failures.