### PR TITLE
Simplify version catalog: remove redundant junitPlatform version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 # libraries
 junit = "4.13.2"
 junitJupiter = "6.1.2"
-junitPlatform = "6.1.2"
 coroutines = "1.10.2"
 opentest4j = "1.3.0"
 ktor = "3.4.3"
@@ -20,7 +19,7 @@ kover = "0.9.9"
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitJupiter" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }


### PR DESCRIPTION
The `junitPlatform` version entry in the version catalog was redundant because the `junit-platform-launcher` dependency now uses the `junitJupiter` version. This change removes the duplicate version declaration and simplifies the catalog.