### PR TITLE
chore: fix qodana problems

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,14 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="EmptyMethod" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="EXCLUDE_ANNOS">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+      <option name="commentsAreContent" value="true" />
+    </inspection_tool>
     <inspection_tool class="HardCodedStringLiteral" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreForAssertStatements" value="true" />
       <option name="ignoreForExceptionConstructors" value="true" />

--- a/plugins/AgentSkillsEditing/src/main/resources/META-INF/plugin.xml
+++ b/plugins/AgentSkillsEditing/src/main/resources/META-INF/plugin.xml
@@ -1,3 +1,4 @@
+<!-- Copyright (c) 2026 ghostflyby -->
 <!-- SPDX-FileCopyrightText: 2026 ghostflyby -->
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
 

--- a/plugins/EnhancedHotSwapEnabler/src/main/kotlin/dev/ghostflyby/dcevm/config/HotswapRunConfigurationExtension.kt
+++ b/plugins/EnhancedHotSwapEnabler/src/main/kotlin/dev/ghostflyby/dcevm/config/HotswapRunConfigurationExtension.kt
@@ -2,22 +2,6 @@
  * Copyright (c) 2025-2026 ghostflyby
  * SPDX-FileCopyrightText: 2025-2026 ghostflyby
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
- * This file is part of IntelliJ-Plugins by ghostflyby
- *
- * IntelliJ-Plugins by ghostflyby is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3.0 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, see
- * <https://www.gnu.org/licenses/>.
  */
 
 package dev.ghostflyby.dcevm.config
@@ -80,6 +64,10 @@ internal class HotswapRunConfigurationExtension : RunConfigurationExtension() {
 
     override fun getEditorTitle(): String = Bundle.message("configuration.section.name")
 
+    /**
+     * Qodana reports EmptyMethod, but super doesn't provide a default and
+     * we don't need any operations.
+     */
     override fun <T : RunConfigurationBase<*>> updateJavaParameters(
         configuration: T,
         params: JavaParameters,

--- a/plugins/VitePress/src/main/resources/META-INF/plugin.xml
+++ b/plugins/VitePress/src/main/resources/META-INF/plugin.xml
@@ -1,3 +1,4 @@
+<!-- Copyright (c) 2026 ghostflyby -->
 <!-- SPDX-FileCopyrightText: 2026 ghostflyby -->
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
 

--- a/plugins/WorkspaceMcpTools/src/main/resources/META-INF/plugin.xml
+++ b/plugins/WorkspaceMcpTools/src/main/resources/META-INF/plugin.xml
@@ -1,3 +1,4 @@
+<!-- Copyright (c) 2026 ghostflyby -->
 <!-- SPDX-FileCopyrightText: 2026 ghostflyby -->
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
 

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileAccessPolicyRoutesTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileAccessPolicyRoutesTest.kt
@@ -85,18 +85,18 @@ internal class FileAccessPolicyRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val meta = sessionClient.get(sessionClient.rootPathUrl("ignored.generated", meta = true)) {
+            val meta = sessionClient.get(rootPathUrl("ignored.generated", meta = true)) {
                 accept(ContentType.Application.Json)
             }
             Assertions.assertEquals(HttpStatusCode.OK, meta.status)
             val parsed = json.parseToJsonElement(meta.bodyAsText()).jsonObject
             Assertions.assertEquals("WORKSPACE_TEXT", parsed["classification"]?.jsonPrimitive?.content)
 
-            val content = sessionClient.get(sessionClient.rootPathUrl("ignored.generated"))
+            val content = sessionClient.get(rootPathUrl("ignored.generated"))
             Assertions.assertEquals(HttpStatusCode.OK, content.status)
             Assertions.assertEquals("ignored", content.bodyAsText().trim())
 
-            val structure = sessionClient.get(sessionClient.rootPathUrl("ignored.generated", structure = true))
+            val structure = sessionClient.get(rootPathUrl("ignored.generated", structure = true))
             Assertions.assertEquals(HttpStatusCode.OK, structure.status)
         }
     }
@@ -107,12 +107,12 @@ internal class FileAccessPolicyRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val denied = sessionClient.put(sessionClient.rootPathUrl("ignored.generated")) {
+            val denied = sessionClient.put(rootPathUrl("ignored.generated")) {
                 setBody("changed")
             }
             Assertions.assertEquals(HttpStatusCode.OK, denied.status)
 
-            val readBack = sessionClient.get(sessionClient.rootPathUrl("ignored.generated"))
+            val readBack = sessionClient.get(rootPathUrl("ignored.generated"))
             Assertions.assertEquals("changed", readBack.bodyAsText().trim())
         }
     }
@@ -124,32 +124,32 @@ internal class FileAccessPolicyRoutesTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
             val root = projectPathFixture.get()
 
-            val putExisting = sessionClient.put(sessionClient.rootPathUrl(".git/config")) {
+            val putExisting = sessionClient.put(rootPathUrl(".git/config")) {
                 setBody("changed")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, putExisting.status)
             Assertions.assertTrue(putExisting.bodyAsText().contains("Git metadata paths are read-only"))
             Assertions.assertEquals("[core]\n", root.resolve(".git/config").toFile().readText())
 
-            val putMissing = sessionClient.put(sessionClient.rootPathUrl(".git/new-file")) {
+            val putMissing = sessionClient.put(rootPathUrl(".git/new-file")) {
                 setBody("new")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, putMissing.status)
             Assertions.assertFalse(Files.exists(root.resolve(".git/new-file")))
 
-            val postDirectory = sessionClient.post(sessionClient.rootPathUrl(".git/new-dir")) {
+            val postDirectory = sessionClient.post(rootPathUrl(".git/new-dir")) {
                 setBody("")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, postDirectory.status)
             Assertions.assertFalse(Files.exists(root.resolve(".git/new-dir")))
 
-            val force = sessionClient.put(sessionClient.rootPathUrl(".git/config", force = true)) {
+            val force = sessionClient.put(rootPathUrl(".git/config", force = true)) {
                 setBody("forced")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, force.status)
             Assertions.assertTrue(force.bodyAsText().contains("force: true"))
 
-            val dotGitSubstring = sessionClient.put(sessionClient.rootPathUrl("foo.git/config")) {
+            val dotGitSubstring = sessionClient.put(rootPathUrl("foo.git/config")) {
                 setBody("changed")
             }
             Assertions.assertEquals(HttpStatusCode.OK, dotGitSubstring.status)
@@ -184,7 +184,7 @@ internal class FileAccessPolicyRoutesTest {
 
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val meta = sessionClient.get(sessionClient.rootPathUrl("src/source.txt", meta = true)) {
+            val meta = sessionClient.get(rootPathUrl("src/source.txt", meta = true)) {
                 accept(ContentType.Application.Json)
             }
             Assertions.assertEquals(HttpStatusCode.OK, meta.status)
@@ -196,12 +196,12 @@ internal class FileAccessPolicyRoutesTest {
                 ?: emptySet()
             Assertions.assertTrue(setOf("put", "patch", "delete").all { it in writableKinds })
 
-            val put = sessionClient.put(sessionClient.rootPathUrl("src/source.txt")) {
+            val put = sessionClient.put(rootPathUrl("src/source.txt")) {
                 setBody("changed source")
             }
             Assertions.assertEquals(HttpStatusCode.OK, put.status)
 
-            val readBack = sessionClient.get(sessionClient.rootPathUrl("src/source.txt"))
+            val readBack = sessionClient.get(rootPathUrl("src/source.txt"))
             Assertions.assertEquals("changed source", readBack.bodyAsText().trim())
         }
     }
@@ -212,22 +212,22 @@ internal class FileAccessPolicyRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val meta = sessionClient.get(sessionClient.rootPathUrl("binary.bin", meta = true)) {
+            val meta = sessionClient.get(rootPathUrl("binary.bin", meta = true)) {
                 accept(ContentType.Application.Json)
             }
             Assertions.assertEquals(HttpStatusCode.OK, meta.status)
             val parsed = json.parseToJsonElement(meta.bodyAsText()).jsonObject
             Assertions.assertEquals("WORKSPACE_BINARY", parsed["classification"]?.jsonPrimitive?.content)
 
-            val put = sessionClient.put(sessionClient.rootPathUrl("binary.bin")) { setBody("nope") }
+            val put = sessionClient.put(rootPathUrl("binary.bin")) { setBody("nope") }
             Assertions.assertEquals(HttpStatusCode.UnsupportedMediaType, put.status)
 
-            val patch = sessionClient.patch(sessionClient.rootPathUrl("binary.bin")) {
+            val patch = sessionClient.patch(rootPathUrl("binary.bin")) {
                 setBody("*** Begin Patch\n*** End Patch")
             }
             Assertions.assertEquals(HttpStatusCode.UnsupportedMediaType, patch.status)
 
-            val delete = sessionClient.delete(sessionClient.rootPathUrl("binary.bin"))
+            val delete = sessionClient.delete(rootPathUrl("binary.bin"))
             Assertions.assertEquals(HttpStatusCode.UnsupportedMediaType, delete.status)
         }
     }
@@ -238,21 +238,21 @@ internal class FileAccessPolicyRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val get = sessionClient.get(sessionClient.rootPathUrl("excluded/hidden.kt"))
+            val get = sessionClient.get(rootPathUrl("excluded/hidden.kt"))
             Assertions.assertEquals(HttpStatusCode.NotFound, get.status)
 
-            val put = sessionClient.put(sessionClient.rootPathUrl("excluded/hidden.kt")) {
+            val put = sessionClient.put(rootPathUrl("excluded/hidden.kt")) {
                 setBody("changed")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, put.status)
 
-            val explicitFalse = sessionClient.put(sessionClient.rootPathUrl("excluded/hidden.kt", force = false)) {
+            val explicitFalse = sessionClient.put(rootPathUrl("excluded/hidden.kt", force = false)) {
                 setBody("changed")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, explicitFalse.status)
             Assertions.assertTrue(explicitFalse.bodyAsText().contains("force: false"))
 
-            val explicitTrue = sessionClient.put(sessionClient.rootPathUrl("excluded/hidden.kt", force = true)) {
+            val explicitTrue = sessionClient.put(rootPathUrl("excluded/hidden.kt", force = true)) {
                 setBody("changed")
             }
             Assertions.assertEquals(HttpStatusCode.Forbidden, explicitTrue.status)

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FilePatchRoutesTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FilePatchRoutesTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 ghostflyby
+ * SPDX-FileCopyrightText: 2026 ghostflyby
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 package dev.ghostflyby.mcp.rest
 
 import com.intellij.testFramework.IndexingTestUtil
@@ -54,13 +60,13 @@ internal class FilePatchRoutesTest {
 -hello sample
 +hello patched
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 header(HttpHeaders.Accept, ContentType.Application.Json.toString())
                 setBody(patch)
             }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals("hello patched", getResp.bodyAsText().trim())
             Assertions.assertEquals("hello patched", projectPathFixture.get().resolve("plain.txt").readText().trim())
         }
@@ -78,12 +84,12 @@ internal class FilePatchRoutesTest {
 +created via patch
 *** End Patch"""
             // Create the parent dir first, then PATCH
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("patch-new.txt")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("patch-new.txt")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             Assertions.assertEquals(TestMarkdownContentType, resp.responseContentType())
             Assertions.assertTrue(resp.bodyAsText().contains("- add patch-new.txt"), resp.bodyAsText())
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("patch-new.txt"))
+            val getResp = sessionClient.get(rootPathUrl("patch-new.txt"))
             Assertions.assertEquals("created via patch", getResp.bodyAsText().trim())
         }
     }
@@ -122,7 +128,7 @@ internal class FilePatchRoutesTest {
 -hello sample
 +hello patched
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 header(HttpHeaders.Accept, ContentType.Application.Json.toString())
                 setBody(patch)
             }
@@ -130,7 +136,7 @@ internal class FilePatchRoutesTest {
             val failed = json.parseToJsonElement(resp.bodyAsText()).jsonObject["failed"]?.jsonArray
             Assertions.assertTrue(failed.isNullOrEmpty())
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals("hello patched", getResp.bodyAsText().trim())
         }
     }
@@ -150,7 +156,7 @@ internal class FilePatchRoutesTest {
 @@ -1 +1 @@
 -hello sample
 +hello git-patched"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 header(HttpHeaders.Accept, ContentType.Application.Json.toString())
                 setBody(diff)
             }
@@ -159,7 +165,7 @@ internal class FilePatchRoutesTest {
             Assertions.assertEquals(1, body["applied"]?.jsonArray?.size)
             Assertions.assertTrue(body["failed"]?.jsonArray.isNullOrEmpty())
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals("hello git-patched", getResp.bodyAsText().trim())
         }
     }
@@ -177,7 +183,7 @@ internal class FilePatchRoutesTest {
 @@ -1 +1 @@
 -hello sample
 +hello git-patched"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 accept(ContentType.Application.Json)
                 setBody(diff)
             }
@@ -185,7 +191,7 @@ internal class FilePatchRoutesTest {
             val failed = json.parseToJsonElement(resp.bodyAsText()).jsonObject["failed"]?.jsonArray
             Assertions.assertTrue(failed.isNullOrEmpty())
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals("hello git-patched", getResp.bodyAsText().trim())
         }
     }
@@ -203,7 +209,7 @@ internal class FilePatchRoutesTest {
 @@ -1 +1 @@
 -hello sample
 +hello git-patched"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 header("Content-Type", "text/x-patch")
                 setBody(diff)
             }
@@ -218,7 +224,7 @@ internal class FilePatchRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 header("Content-Type", "text/x-patch")
                 setBody("*** Begin Patch")
             }
@@ -241,7 +247,7 @@ new file mode 100644
 +++ b/newfile.txt
 @@ -0,0 +1 @@
 +created by git patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("newfile.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("newfile.txt")) {
                 setBody(diff)
             }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
@@ -261,12 +267,12 @@ deleted file mode 100644
 +++ /dev/null
 @@ -1 +0,0 @@
 -hello sample"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 setBody(diff)
             }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals(HttpStatusCode.NotFound, getResp.status)
         }
     }
@@ -285,7 +291,7 @@ deleted file mode 100644
 *** Add File: newfile.txt
 +created under directory
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val text = resp.bodyAsText()
             Assertions.assertTrue(text.contains("foo.xml"))
@@ -305,12 +311,12 @@ deleted file mode 100644
 -<foo/>
 +<root><child/></root>
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
 
-            val foo = sessionClient.get(sessionClient.rootPathUrl("src/foo.xml"))
+            val foo = sessionClient.get(rootPathUrl("src/foo.xml"))
             Assertions.assertEquals("<root><child/></root>", foo.bodyAsText().trim())
-            val bar = sessionClient.get(sessionClient.rootPathUrl("src/bar.xml"))
+            val bar = sessionClient.get(rootPathUrl("src/bar.xml"))
             Assertions.assertEquals("<bar/>", bar.bodyAsText().trim())
         }
     }
@@ -326,16 +332,16 @@ deleted file mode 100644
 *** Update File: bar.xml
 *** Move to: moved-bar.xml
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             Assertions.assertFalse(body.contains("Read access is allowed"), body)
             Assertions.assertFalse(body.contains("failed:"), body)
 
-            val moved = sessionClient.get(sessionClient.rootPathUrl("src/moved-bar.xml"))
+            val moved = sessionClient.get(rootPathUrl("src/moved-bar.xml"))
             Assertions.assertEquals("<bar/>", moved.bodyAsText().trim())
 
-            val old = sessionClient.get(sessionClient.rootPathUrl("src/bar.xml"))
+            val old = sessionClient.get(rootPathUrl("src/bar.xml"))
             Assertions.assertEquals(HttpStatusCode.NotFound, old.status)
         }
     }
@@ -351,14 +357,14 @@ deleted file mode 100644
 *** Update File: bar.xml
 *** Move to: moved/bar-renamed.xml
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             Assertions.assertTrue(resp.bodyAsText().contains("- update src/bar.xml"), resp.bodyAsText())
 
-            val moved = sessionClient.get(sessionClient.rootPathUrl("src/moved/bar-renamed.xml"))
+            val moved = sessionClient.get(rootPathUrl("src/moved/bar-renamed.xml"))
             Assertions.assertEquals("<bar/>", moved.bodyAsText().trim())
 
-            val old = sessionClient.get(sessionClient.rootPathUrl("src/bar.xml"))
+            val old = sessionClient.get(rootPathUrl("src/bar.xml"))
             Assertions.assertEquals(HttpStatusCode.NotFound, old.status)
         }
     }
@@ -377,12 +383,12 @@ deleted file mode 100644
 *** Update File: bar.xml
 *** Move to: .git/moved.xml
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             Assertions.assertTrue(body.contains("Git metadata paths are read-only"), body)
 
-            val original = sessionClient.get(sessionClient.rootPathUrl("src/bar.xml"))
+            val original = sessionClient.get(rootPathUrl("src/bar.xml"))
             Assertions.assertEquals(HttpStatusCode.OK, original.status)
             Assertions.assertEquals("<bar/>", original.bodyAsText().trim())
 
@@ -407,7 +413,7 @@ deleted file mode 100644
 -[core]
 +changed
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             Assertions.assertTrue(body.contains("Git metadata paths are read-only"), body)
@@ -451,18 +457,18 @@ deleted file mode 100644
 *** Update File: pkg/Alpha.java
 *** Move to: moved/Alpha.java
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             Assertions.assertFalse(resp.bodyAsText().contains("failed:"), resp.bodyAsText())
 
-            val moved = sessionClient.get(sessionClient.rootPathUrl("src/moved/Alpha.java"))
+            val moved = sessionClient.get(rootPathUrl("src/moved/Alpha.java"))
             Assertions.assertEquals(HttpStatusCode.OK, moved.status)
             Assertions.assertTrue(moved.bodyAsText().contains("public class Alpha"), moved.bodyAsText())
 
-            val old = sessionClient.get(sessionClient.rootPathUrl("src/pkg/Alpha.java"))
+            val old = sessionClient.get(rootPathUrl("src/pkg/Alpha.java"))
             Assertions.assertEquals(HttpStatusCode.NotFound, old.status)
 
-            val beta = sessionClient.get(sessionClient.rootPathUrl("src/pkg/Beta.java"))
+            val beta = sessionClient.get(rootPathUrl("src/pkg/Beta.java"))
             Assertions.assertEquals(HttpStatusCode.OK, beta.status)
             val betaText = beta.bodyAsText()
             Assertions.assertTrue(betaText.contains("public String call(Alpha target)"), betaText)
@@ -479,7 +485,7 @@ deleted file mode 100644
             val patch = """*** Begin Patch
 *** Reformat File: foo.xml
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             Assertions.assertTrue(body.contains("- reformat src/foo.xml"), body)
@@ -496,7 +502,7 @@ deleted file mode 100644
             val patch = """*** Begin Patch
 *** Cleanup: foo.xml
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             Assertions.assertTrue(body.contains("- cleanup src/foo.xml"), body)
@@ -515,7 +521,7 @@ deleted file mode 100644
 *** Optimize Imports: foo.xml
 *** Cleanup: foo.xml
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             val cleanup = body.indexOf("- cleanup src/foo.xml")
@@ -541,7 +547,7 @@ deleted file mode 100644
 +  *** Cleanup: src/B.kt
 +after
 *** End Patch"""
-            val createResp = sessionClient.patch(sessionClient.rootPathUrl("operation-doc.md")) { setBody(create) }
+            val createResp = sessionClient.patch(rootPathUrl("operation-doc.md")) { setBody(create) }
             Assertions.assertEquals(HttpStatusCode.OK, createResp.status)
 
             val update = """*** Begin Patch
@@ -552,12 +558,12 @@ deleted file mode 100644
 -after
 +after updated
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("operation-doc.md")) { setBody(update) }
+            val resp = sessionClient.patch(rootPathUrl("operation-doc.md")) { setBody(update) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val body = resp.bodyAsText()
             Assertions.assertFalse(body.contains("File not found: src/B.kt"), body)
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("operation-doc.md"))
+            val getResp = sessionClient.get(rootPathUrl("operation-doc.md"))
             Assertions.assertEquals(
                 """before
   *** Cleanup: src/B.kt
@@ -574,7 +580,7 @@ after updated""",
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val resp = sessionClient.patch("${sessionClient.rootPathUrl("plain.txt")}?problemFix=true") {
+            val resp = sessionClient.patch("${rootPathUrl("plain.txt")}?problemFix=true") {
                 setBody(
                     """*** Begin Patch
 *** Fix Problem
@@ -602,7 +608,7 @@ after updated""",
  -nothing
 +something
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("src")) { setBody(patch) }
+            val resp = sessionClient.patch(rootPathUrl("src")) { setBody(patch) }
             Assertions.assertEquals(HttpStatusCode.OK, resp.status)
             val text = resp.bodyAsText()
             Assertions.assertTrue(text.contains("failed"))
@@ -616,7 +622,7 @@ after updated""",
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("plain.txt")) {
+            val resp = sessionClient.patch(rootPathUrl("plain.txt")) {
                 setBody("this is not a patch")
             }
             Assertions.assertEquals(HttpStatusCode.BadRequest, resp.status)
@@ -635,7 +641,7 @@ after updated""",
 +<root>
 +    <unclosed
 *** End Patch"""
-            val resp = sessionClient.patch(sessionClient.rootPathUrl("broken.xml")) {
+            val resp = sessionClient.patch(rootPathUrl("broken.xml")) {
                 setBody(patch)
             }
             Assertions.assertTrue(resp.bodyAsText().contains("applied:"), "PATCH should succeed")

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileRootTestSupport.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileRootTestSupport.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 ghostflyby
+ * SPDX-FileCopyrightText: 2026 ghostflyby
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 package dev.ghostflyby.mcp.rest
 
 import io.ktor.client.*
@@ -62,35 +68,7 @@ internal suspend fun HttpClient.withRestSession(pathPrefix: String, json: Json):
     }
 }
 
-internal fun HttpClient.rootPathUrl(
-    relativePath: String,
-    meta: Boolean? = null,
-    content: Boolean? = null,
-    exists: Boolean? = null,
-    structure: Boolean? = null,
-    force: Boolean? = null,
-    startLine: Int? = null,
-    endLine: Int? = null,
-    maxLines: Int? = null,
-    aroundLine: Int? = null,
-    radius: Int? = null,
-): String {
-    return dev.ghostflyby.mcp.rest.rootPathUrl(
-        relativePath,
-        meta,
-        content,
-        exists,
-        structure,
-        force,
-        startLine,
-        endLine,
-        maxLines,
-        aroundLine,
-        radius,
-    )
-}
-
-internal fun HttpClient.rootPathUrlByRootUrl(
+internal fun rootPathUrlByRootUrl(
     relativePath: String,
     meta: Boolean? = null,
     content: Boolean? = null,

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileWriteRoutesTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/FileWriteRoutesTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026 ghostflyby
+ * SPDX-FileCopyrightText: 2026 ghostflyby
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
 package dev.ghostflyby.mcp.rest
 
 import com.intellij.testFramework.IndexingTestUtil
@@ -43,7 +49,7 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.post(sessionClient.rootPathUrl("new.txt")) {
+            val response = sessionClient.post(rootPathUrl("new.txt")) {
                 setBody("fresh content")
             }
             Assertions.assertEquals(HttpStatusCode.Created, response.status)
@@ -52,7 +58,7 @@ internal class FileWriteRoutesTest {
             Assertions.assertTrue(response.bodyAsText().contains("encodedUri: file%3A%2F%2F"), response.bodyAsText())
 
             // Verify file exists via GET
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("new.txt"))
+            val getResp = sessionClient.get(rootPathUrl("new.txt"))
             Assertions.assertEquals(HttpStatusCode.OK, getResp.status)
             Assertions.assertEquals("fresh content", getResp.bodyAsText().trim())
         }
@@ -65,7 +71,7 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.post(sessionClient.rootPathUrl("newdir")) {
+            val response = sessionClient.post(rootPathUrl("newdir")) {
                 setBody("")
             }
             Assertions.assertEquals(HttpStatusCode.Created, response.status)
@@ -80,7 +86,7 @@ internal class FileWriteRoutesTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             // plain.txt exists from blueprint
-            val response = sessionClient.post(sessionClient.rootPathUrl("plain.txt")) {
+            val response = sessionClient.post(rootPathUrl("plain.txt")) {
                 setBody("overwrite attempt")
             }
             Assertions.assertEquals(HttpStatusCode.Conflict, response.status)
@@ -96,7 +102,7 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.put(sessionClient.rootPathUrl("put-created.txt")) {
+            val response = sessionClient.put(rootPathUrl("put-created.txt")) {
                 setBody("put content")
             }
             Assertions.assertEquals(HttpStatusCode.Created, response.status)
@@ -110,12 +116,12 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.put(sessionClient.rootPathUrl("plain.txt")) {
+            val response = sessionClient.put(rootPathUrl("plain.txt")) {
                 setBody("replaced content")
             }
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals("replaced content", getResp.bodyAsText().trim())
         }
     }
@@ -155,13 +161,13 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.delete(sessionClient.rootPathUrl("plain.txt"))
+            val response = sessionClient.delete(rootPathUrl("plain.txt"))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals(TestMarkdownContentType, response.responseContentType())
             Assertions.assertTrue(response.bodyAsText().contains("deleted: true"), response.bodyAsText())
             Assertions.assertTrue(response.bodyAsText().contains("referenceCount: 0"), response.bodyAsText())
 
-            val getResp = sessionClient.get(sessionClient.rootPathUrl("plain.txt"))
+            val getResp = sessionClient.get(rootPathUrl("plain.txt"))
             Assertions.assertEquals(HttpStatusCode.NotFound, getResp.status)
         }
     }
@@ -173,7 +179,7 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.delete(sessionClient.rootPathUrl("doesnotexist.txt"))
+            val response = sessionClient.delete(rootPathUrl("doesnotexist.txt"))
             Assertions.assertEquals(HttpStatusCode.NotFound, response.status)
         }
     }
@@ -185,7 +191,7 @@ internal class FileWriteRoutesTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.delete(sessionClient.rootPathUrl("src"))
+            val response = sessionClient.delete(rootPathUrl("src"))
             Assertions.assertEquals(HttpStatusCode.Conflict, response.status)
         }
     }

--- a/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/RestFileTest.kt
+++ b/plugins/WorkspaceMcpTools/src/test/kotlin/dev/ghostflyby/mcp/rest/RestFileTest.kt
@@ -77,7 +77,7 @@ internal class RestFileTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.get(sessionClient.rootPathUrlByRootUrl("plain.txt"))
+            val response = sessionClient.get(rootPathUrlByRootUrl("plain.txt"))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals("hello sample", response.bodyAsText().trim())
         }
@@ -91,7 +91,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response =
-                sessionClient.get(sessionClient.rootPathUrlByRootUrl("plain.txt", meta = true)) {
+                sessionClient.get(rootPathUrlByRootUrl("plain.txt", meta = true)) {
                     accept(ContentType.Application.Json)
                 }
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
@@ -117,7 +117,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response =
-                sessionClient.get(sessionClient.rootPathUrlByRootUrl("plain.txt", meta = true))
+                sessionClient.get(rootPathUrlByRootUrl("plain.txt", meta = true))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals(TestMarkdownContentType, response.responseContentType())
 
@@ -136,7 +136,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response =
-                sessionClient.get(sessionClient.rootPathUrlByRootUrl("plain.txt", meta = false))
+                sessionClient.get(rootPathUrlByRootUrl("plain.txt", meta = false))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals("hello sample", response.bodyAsText().trim())
         }
@@ -150,7 +150,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response =
-                sessionClient.get(sessionClient.rootPathUrlByRootUrl("plain.txt", exists = true))
+                sessionClient.get(rootPathUrlByRootUrl("plain.txt", exists = true))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals("true", response.bodyAsText())
         }
@@ -164,7 +164,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response =
-                sessionClient.get(sessionClient.rootPathUrlByRootUrl("missing.txt", exists = true))
+                sessionClient.get(rootPathUrlByRootUrl("missing.txt", exists = true))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals("false", response.bodyAsText())
         }
@@ -177,7 +177,7 @@ internal class RestFileTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.get(sessionClient.rootPathUrlByRootUrl("nonexistent.txt"))
+            val response = sessionClient.get(rootPathUrlByRootUrl("nonexistent.txt"))
             Assertions.assertEquals(HttpStatusCode.NotFound, response.status)
         }
     }
@@ -189,11 +189,11 @@ internal class RestFileTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val response = sessionClient.get(sessionClient.rootPathUrlByRootUrl("plain.txt"))
+            val response = sessionClient.get(rootPathUrlByRootUrl("plain.txt"))
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals("hello sample", response.bodyAsText().trim())
 
-            val missing = sessionClient.get(sessionClient.rootPathUrlByRootUrl("not-found.txt"))
+            val missing = sessionClient.get(rootPathUrlByRootUrl("not-found.txt"))
             Assertions.assertEquals(HttpStatusCode.NotFound, missing.status)
         }
     }
@@ -226,7 +226,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response =
-                sessionClient.get("${sessionClient.rootPathUrl("broken.xml")}?problems=true&minSeverity=ERROR")
+                sessionClient.get("${rootPathUrl("broken.xml")}?problems=true&minSeverity=ERROR")
             Assertions.assertEquals(HttpStatusCode.OK, response.status)
             Assertions.assertEquals(TestMarkdownContentType, response.responseContentType())
             val body = response.bodyAsText()
@@ -291,7 +291,7 @@ internal class RestFileTest {
 
             val response =
                 sessionClient.get(
-                    sessionClient.rootPathUrlByRootUrl(
+                    rootPathUrlByRootUrl(
                         "plain.txt",
                         meta = true,
                         content = true,
@@ -318,7 +318,7 @@ internal class RestFileTest {
 
             val response =
                 sessionClient.get(
-                    sessionClient.rootPathUrlByRootUrl(
+                    rootPathUrlByRootUrl(
                         "plain.txt",
                         meta = true,
                         content = true,
@@ -342,7 +342,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val jsonResponse = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("glob/RootFile.kt", structure = true),
+                rootPathUrlByRootUrl("glob/RootFile.kt", structure = true),
             ) {
                 accept(ContentType.Application.Json)
             }
@@ -353,7 +353,7 @@ internal class RestFileTest {
             Assertions.assertTrue(elements.hasElementWithLineRange(), jsonResponse.bodyAsText())
 
             val markdown = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("glob/RootFile.kt", structure = true),
+                rootPathUrlByRootUrl("glob/RootFile.kt", structure = true),
             )
             Assertions.assertEquals(HttpStatusCode.OK, markdown.status)
             Assertions.assertTrue(Regex("""\[\d+-\d+]""").containsMatchIn(markdown.bodyAsText()), markdown.bodyAsText())
@@ -368,18 +368,18 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val byEnd = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("range.txt", startLine = 2, endLine = 4),
+                rootPathUrlByRootUrl("range.txt", startLine = 2, endLine = 4),
             )
             Assertions.assertEquals(HttpStatusCode.OK, byEnd.status)
             Assertions.assertEquals("two\nthree\nfour", byEnd.bodyAsText())
 
             val byMax = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("range.txt", startLine = 3, maxLines = 2),
+                rootPathUrlByRootUrl("range.txt", startLine = 3, maxLines = 2),
             )
             Assertions.assertEquals("three\nfour", byMax.bodyAsText())
 
             val around = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("range.txt", aroundLine = 3, radius = 1),
+                rootPathUrlByRootUrl("range.txt", aroundLine = 3, radius = 1),
             )
             Assertions.assertEquals("two\nthree\nfour", around.bodyAsText())
         }
@@ -393,7 +393,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val response = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl(
+                rootPathUrlByRootUrl(
                     "range.txt",
                     meta = true,
                     content = true,
@@ -420,7 +420,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val exists = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl(
+                rootPathUrlByRootUrl(
                     "range.txt",
                     exists = true,
                     startLine = 1,
@@ -435,7 +435,7 @@ internal class RestFileTest {
             Assertions.assertEquals("one\ntwo", existsBody["content"]?.jsonPrimitive?.content)
 
             val structure = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl(
+                rootPathUrlByRootUrl(
                     "glob/RootFile.kt",
                     meta = true,
                     structure = true,
@@ -463,7 +463,7 @@ internal class RestFileTest {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
             val invalidCombination = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl(
+                rootPathUrlByRootUrl(
                     "range.txt",
                     startLine = 1,
                     endLine = 2,
@@ -473,17 +473,17 @@ internal class RestFileTest {
             Assertions.assertEquals(HttpStatusCode.BadRequest, invalidCombination.status)
 
             val invalidValue = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("range.txt", startLine = 0, endLine = 1),
+                rootPathUrlByRootUrl("range.txt", startLine = 0, endLine = 1),
             )
             Assertions.assertEquals(HttpStatusCode.BadRequest, invalidValue.status)
 
             val directory = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("src", startLine = 1, endLine = 1),
+                rootPathUrlByRootUrl("src", startLine = 1, endLine = 1),
             )
             Assertions.assertEquals(HttpStatusCode.BadRequest, directory.status)
 
             val binary = sessionClient.get(
-                sessionClient.rootPathUrlByRootUrl("binary.bin", startLine = 1, endLine = 1),
+                rootPathUrlByRootUrl("binary.bin", startLine = 1, endLine = 1),
             )
             Assertions.assertEquals(HttpStatusCode.BadRequest, binary.status)
         }
@@ -622,12 +622,12 @@ internal class RestFileTest {
         restTestApplication {
             val sessionClient = client.withRestSession(projectPathFixture.get().toString(), json)
 
-            val defaultResponse = sessionClient.get(sessionClient.rootPathUrlByRootUrl("src"))
+            val defaultResponse = sessionClient.get(rootPathUrlByRootUrl("src"))
             Assertions.assertEquals(HttpStatusCode.OK, defaultResponse.status)
             Assertions.assertEquals(TestMarkdownContentType, defaultResponse.responseContentType())
             Assertions.assertTrue(defaultResponse.bodyAsText().lines().any { it.isNotBlank() })
 
-            val jsonResponse = sessionClient.get(sessionClient.rootPathUrlByRootUrl("src")) {
+            val jsonResponse = sessionClient.get(rootPathUrlByRootUrl("src")) {
                 accept(ContentType.Application.Json)
             }
             Assertions.assertEquals(HttpStatusCode.OK, jsonResponse.status)

--- a/plugins/macOSRecents/src/main/resources/META-INF/plugin.xml
+++ b/plugins/macOSRecents/src/main/resources/META-INF/plugin.xml
@@ -1,3 +1,4 @@
+<!-- Copyright (c) 2026 ghostflyby -->
 <!-- SPDX-FileCopyrightText: 2025-2026 ghostflyby -->
 <!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
 
@@ -16,5 +17,4 @@
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="dev.ghostflyby.mac.recents.StartUp" os="mac"/>
     </extensions>
-
 </idea-plugin>


### PR DESCRIPTION
Removed the `sessionClient.` prefix from calls to `rootPathUrl` in REST tests to simplify the code and align with recent API changes.